### PR TITLE
SourceClear: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,11 +124,11 @@
         <commons-logging.version>1.2</commons-logging.version>
         <coveralls-maven-plugin.version>4.0.0</coveralls-maven-plugin.version>
         <ecs.version>1.4.2</ecs.version>
-        <guava.version>18.0</guava.version>
-        <h2.version>1.4.190</h2.version>
+        <guava.version>24.1.1-android</guava.version>
+        <h2.version>1.4.198</h2.version>
         <hsqldb.version>1.8.0.10</hsqldb.version>
         <j2h.version>1.3.1</j2h.version>
-        <jackson-core.version>2.6.3</jackson-core.version>
+        <jackson-core.version>2.8.6</jackson-core.version>
         <jackson-databind.version>2.6.3</jackson-databind.version>
         <javaee-api.version>6.0</javaee-api.version>
         <javax.transaction-api.version>1.2</javax.transaction-api.version>
@@ -148,7 +148,7 @@
         <maven-surefire-plugin.version>2.19</maven-surefire-plugin.version>
         <maven-war-plugin.version>2.6</maven-war-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.6</nexus-staging-maven-plugin.version>
-        <org.springframework.version>3.2.4.RELEASE</org.springframework.version>
+        <org.springframework.version>4.3.20.RELEASE</org.springframework.version>
         <sauce_junit.version>2.1.20</sauce_junit.version>
         <selenium-java.version>2.48.2</selenium-java.version>
         <slf4j-api.version>1.7.12</slf4j-api.version>


### PR DESCRIPTION
This pull request fixes one or more vulnerable libraries in this project.

For more information, please navigate to the corresponding [SourceClear report](https://grove64.sourceclear.io/teams/3OOuyxb/scans/6501990).

SourceClear generated this pull request to update the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `com.h2database:h2` | 1.4.190 | 1.4.198 | No |
| MAVEN | `org.springframework:spring-webmvc` | 3.2.4.RELEASE | 4.3.20.RELEASE | Maybe |
| MAVEN | `com.google.guava:guava` | 18.0 | 24.1.1-android | Maybe |
| MAVEN | `com.fasterxml.jackson.core:jackson-core` | 2.6.3 | 2.8.6 | No |

The column above, **Breaking**, will state the likelihood that updating to the recommended library version will have breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/reader/hHHR3gv0wYc2WbCclECf_A/root) for documentation.

Note: this pull request was generated because you or someone else with access to this repository has granted SourceClear access to submit pull requests.
<!-- srcclr-pr-id-dcc7671f2ae33a142e5eec7de1dcc5739204b4143fa734e4ae4554b5a4b15aaa -->
